### PR TITLE
Deploy frontend & change IP

### DIFF
--- a/Atlas/backend/README.md
+++ b/Atlas/backend/README.md
@@ -1,6 +1,6 @@
 # Atlas Backend
 Project can be visited here:
-http://34.234.93.208/
+http://54.235.57.209/
 
 # Setting up the development environment
 

--- a/Atlas/backend/atlas/settings.py
+++ b/Atlas/backend/atlas/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = 'b!ydx6z#0z%59+*@%(sfj&fynlk&73eyh4$+58%*ft%kfm43-c'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv('ATLAS_DEBUG', False)
 
-ALLOWED_HOSTS = ['34.234.93.208',
+ALLOWED_HOSTS = ['54.235.57.209',
                  '0.0.0.0',
                  'localhost']
 

--- a/Atlas/frontend/package.json
+++ b/Atlas/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "homepage": "http://54.235.57.209/",
   "dependencies": {
     "bootstrap": "^4.0.0-beta",
     "node-sass-chokidar": "0.0.3",


### PR DESCRIPTION
This PR has
- Deployed frontend to `http://54.235.57.209/`
- Deployed backend to `http://54.235.57.209:81/` (you can try the `/admin` endpoint)

## Why did our IP address change?

Our Amazon EC2 instance's memory was not enough to run `npm install` hence I upgraded its memory from 512 to 1k. After that, I configured the swap memory so that hopefully we won't have any memory issues in the future.

## Future Plans
- Get a domain like `atlasgroup10.com`
- Bind port 80 (frontend) to `atlasgroup10.com`
- Bind port 81 (backend) to subdomain `api.atlasgroup10.com`