### PR TITLE
Add cors headers package to requirements

### DIFF
--- a/Atlas/backend/requirements.txt
+++ b/Atlas/backend/requirements.txt
@@ -2,6 +2,10 @@ blinker==1.3
 chardet==2.3.0
 configobj==5.0.6
 Django==1.11.5
+django-cors-headers==2.1.0
+django-jwt-auth==0.0.2
+djangorestframework==3.3.2
+djangorestframework-jwt==1.8.0
 idna==2.0
 Jinja2==2.8
 jsonpatch==1.10
@@ -9,19 +13,15 @@ jsonpointer==1.9
 MarkupSafe==0.23
 oauthlib==1.0.3
 prettytable==0.7.2
+psycopg2==2.7.3.1
+py==1.4.34
 pyasn1==0.1.9
-
 PyJWT==1.3.0
 pyserial==3.0.1
+pytest==3.2.2
 pytz==2017.2
 PyYAML==3.11
 requests==2.9.1
 six==1.10.0
 urllib3==1.13.1
 virtualenv==15.1.0
-psycopg2==2.7.3.1
-
-djangorestframework==3.3.2
-djangorestframework-jwt==1.8.0
-pytest == 3.2.2
-django-jwt-auth == 0.0.2


### PR DESCRIPTION
I added cors dependency for xhr requests from UI app, and forgot to freeze pip & add it to `requirements.txt` file. This should be merged, currently backend is broken.