### PR TITLE
Add Initial settings for Swagger

### DIFF
--- a/Atlas/backend/atlas/settings.py
+++ b/Atlas/backend/atlas/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'atlas.apps.AtlasConfig',
     'rest_framework',
+    'rest_framework_swagger',
     'authentication',
     'corsheaders',
 ]
@@ -129,9 +130,14 @@ AUTH_USER_MODEL = 'authentication.Account'
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
+STATIC_ROOT = os.path.join(BASE_DIR,'static')
 
 STATIC_URL = '/static/'
-STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
+
+STATICFILES_DIRS = (
+
+)
+
 
 # Rest Framework permissions and authentication middleware
 REST_FRAMEWORK = {

--- a/Atlas/backend/atlas/urls.py
+++ b/Atlas/backend/atlas/urls.py
@@ -15,11 +15,19 @@ Including another URLconf
 """
 from django.conf.urls import url,include
 from django.contrib import admin
+from rest_framework_swagger.views import get_swagger_view
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 from. import views
 
+schema_view = get_swagger_view(title='ATLAS API DOCUMENTS')
+
 urlpatterns = [
+
+    url(r'^swagger/', schema_view),
     url(r'^admin/', admin.site.urls),
     url(r'^users/', views.users, name='users'),
     url(r'^api/auth/', include('authentication.urls')),
 ]
+
+urlpatterns += staticfiles_urlpatterns()

--- a/Atlas/backend/requirements.txt
+++ b/Atlas/backend/requirements.txt
@@ -4,7 +4,7 @@ configobj==5.0.6
 Django==1.11.5
 django-cors-headers==2.1.0
 django-jwt-auth==0.0.2
-djangorestframework==3.3.2
+djangorestframework==3.7.1
 djangorestframework-jwt==1.8.0
 idna==2.0
 Jinja2==2.8

--- a/Atlas/backend/requirements.txt
+++ b/Atlas/backend/requirements.txt
@@ -25,3 +25,4 @@ requests==2.9.1
 six==1.10.0
 urllib3==1.13.1
 virtualenv==15.1.0
+django-rest-swagger==2.1.2


### PR DESCRIPTION
Just the configuration of Swagger. You can test the swagger page rendered with running
`./manage.py runserver --insecure`
the server in insecure mode. Insecure mode:

> Use the --insecure option to force serving of static files with the staticfiles app even if the DEBUG setting is False. By using this you acknowledge the fact that it’s grossly inefficient and probably insecure. This is only intended for local development, should never be used in production and is only available if the staticfiles app is in your project’s INSTALLED_APPS setting. 

We can use this page like this until we implement further static file serving method