### PR TITLE
Add all fields to cultural heritage item serializer and test it

### DIFF
--- a/Atlas/backend/atlas/serializers.py
+++ b/Atlas/backend/atlas/serializers.py
@@ -9,3 +9,4 @@ class cultural_heritage_serializer(serializers.ModelSerializer):
     user = AccountSerializer
     class Meta:
         model = Cultural_Heritage
+        fields = '__all__'

--- a/Atlas/backend/atlas/tests.py
+++ b/Atlas/backend/atlas/tests.py
@@ -8,8 +8,7 @@ from authentication.models import Account
 from rest_framework.test import APIClient
 
 
-#response_content = json.loads(smart_text(response.content))
-#print(response_content)
+
 @pytest.mark.django_db
 class cultural_heritage_item(TestCase):
     def setUp(self):
@@ -112,3 +111,24 @@ class cultural_heritage_item(TestCase):
 
         )
         self.assertEqual(response.status_code, 400)
+
+    def test_get_cultural_heritage_item(self):
+        title = 'Very emotional thresh hook'
+        item_data = {
+            "title": title,
+        }
+        response = self.client.post(
+            self.cultural_heritage_item_url,
+            item_data,
+            format='json',
+
+        )
+        self.assertEqual(response.status_code,201)
+        response = self.client.get(
+            self.cultural_heritage_item_url,
+            format='json',
+
+        )
+        self.assertEqual(response.status_code, 200)
+        response_content = json.loads(smart_text(response.content))
+        self.assertEqual(response_content[0]['title'] ,title)


### PR DESCRIPTION
'fields' field was missing in the serializer. It is fixed.
This partially fixes #160, getting cultural heritage items by their id will be added later. 
