### PR TITLE
Android token store

### DIFF
--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/auth/AuthActivity.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/auth/AuthActivity.java
@@ -1,5 +1,6 @@
 package com.bounswe2017.group10.atlas.auth;
 
+import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
@@ -12,7 +13,10 @@ import android.view.WindowManager;
 import android.widget.FrameLayout;
 
 import com.bounswe2017.group10.atlas.R;
+import com.bounswe2017.group10.atlas.home.HomeActivity;
 import com.bounswe2017.group10.atlas.util.BlurBuilder;
+import com.bounswe2017.group10.atlas.util.Constants;
+import com.bounswe2017.group10.atlas.util.Utils;
 
 public class AuthActivity extends FragmentActivity {
     @Override
@@ -26,6 +30,17 @@ public class AuthActivity extends FragmentActivity {
         if (savedInstanceState != null) {
             return;
         }
+        // if there is a stored token, automatically log in.
+        if (Utils.getSharedPref(this).contains(Constants.AUTH_STR)) {
+            // refresh token
+            String authStr = Utils.getSharedPref(this).getString(Constants.AUTH_STR, Constants.NO_AUTH_STR);
+            // TODO: refresh token with token-refresh endpoint.
+            // log user in automatically
+            Intent intent = new Intent(this, HomeActivity.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK|Intent.FLAG_ACTIVITY_NEW_TASK);
+            startActivity(intent);
+        }
+
         // Do the following operations only when the activity is created for the first time
 
         // blur layout background

--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/home/CreateItemFragment.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/home/CreateItemFragment.java
@@ -41,14 +41,10 @@ public class CreateItemFragment extends Fragment {
     private ImageListAdapter mAdapter;
     private final ArrayList<ImageRow> mImageRowList = new ArrayList<>();
 
-    private String authStr;
-
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_create_item, container, false);
-
-        authStr = getActivity().getIntent().getStringExtra(Constants.AUTH_STR);
 
         ListView imageListView = view.findViewById(R.id.image_listview);
         //Button btnGallery = view.findViewById(R.id.gallery_button);
@@ -97,7 +93,7 @@ public class CreateItemFragment extends Fragment {
             item.setCity(etCity.getText().toString());
             item.setPublicAccessibility(true);
 
-            List<Image> imageList = new ArrayList<>();
+            ArrayList<Image> imageList = new ArrayList<>();
             for (ImageRow row : mImageRowList) {
                 Image img = new Image();
                 img.setUrl(row.getUrl());
@@ -132,7 +128,9 @@ public class CreateItemFragment extends Fragment {
      */
     private void makeCreateRequest(CultureItem item, ProgressBar progressBar) {
         progressBar.setVisibility(View.VISIBLE);
-        APIUtils.serverAPI().createItem(authStr, item).enqueue(new OnCreateItemResponse(getActivity(), progressBar));
+        Activity activity = getActivity();
+        String authStr = Utils.getSharedPref(activity).getString(Constants.AUTH_STR, Constants.NO_AUTH_STR);
+        APIUtils.serverAPI().createItem(authStr, item).enqueue(new OnCreateItemResponse(activity, progressBar));
     }
 
     /**

--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/home/FeedFragment.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/home/FeedFragment.java
@@ -10,80 +10,46 @@ import com.bounswe2017.group10.atlas.adapter.FeedListAdapter;
 import com.bounswe2017.group10.atlas.adapter.FeedRow;
 import com.bounswe2017.group10.atlas.httpbody.CultureItem;
 import com.bounswe2017.group10.atlas.remote.APIUtils;
+import com.bounswe2017.group10.atlas.response.OnGetAllItemsResponse;
 import com.bounswe2017.group10.atlas.util.Constants;
 import java.util.ArrayList;
-import retrofit2.Call;
-import retrofit2.Callback;
-import retrofit2.Response;
 
-import static com.bounswe2017.group10.atlas.util.Utils.tokenToAuthString;
+import static com.bounswe2017.group10.atlas.util.Utils.getSharedPref;
 
 public class FeedFragment extends ListFragment {
 
     private final ArrayList<CultureItem> mItemList = new ArrayList<>();
     private final ArrayList<FeedRow> mRowList = new ArrayList<>();
     private FeedListAdapter mAdapter;
-    private String authStr;
 
     @Nullable
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        authStr = getActivity().getIntent().getStringExtra(Constants.AUTH_STR);
-
-        // TODO: get all items
-        // TODO: get items only when created; not always.
-        APIUtils.serverAPI().getItem(authStr, 3).enqueue(new OnGetItemResponse());
-        APIUtils.serverAPI().getItem(authStr, 4).enqueue(new OnGetItemResponse());
-        APIUtils.serverAPI().getItem(authStr, 5).enqueue(new OnGetItemResponse());
+        String authStr = getSharedPref(getActivity()).getString(Constants.AUTH_STR, Constants.NO_AUTH_STR);
 
         mAdapter = new FeedListAdapter(getActivity(), mRowList);
         setListAdapter(mAdapter);
+
+        // currently, get all items
+        OnGetAllItemsResponse respHandler = new OnGetAllItemsResponse(getActivity(), mItemList, mRowList, mAdapter);
+        APIUtils.serverAPI().getAllItems(authStr).enqueue(respHandler);
     }
 
     @Override
     public void onListItemClick(ListView listView, View view, int pos, long id) {
-
+        // put item to bundle
+        Bundle itemBundle = new Bundle();
+        itemBundle.putParcelable(Constants.CULTURE_ITEM, mItemList.get(pos));
+        // put bundle to fragment
         ViewItemFragment viewItemFragment = new ViewItemFragment();
-        Bundle bundle = new Bundle();
-        bundle.putString("authStr", authStr);
-        viewItemFragment.setObj(mItemList.get(pos));
-        viewItemFragment.setArguments(bundle);
+        viewItemFragment.setArguments(itemBundle);
+        // go to fragment
         getActivity().getSupportFragmentManager()
                 .beginTransaction()
                 .replace(R.id.home_container, viewItemFragment)
                 .addToBackStack(null)
                 .commit();
-    }
-
-    /**
-     * Adds a culture item to current buffers and notifies the adapter of the changes.
-     *
-     * Culture item itself is added to culture items list. Its corresponding FeedRow object
-     * is added to FeedRow list.
-     *
-     * @param item CultureItem object to be stored.
-     */
-    private void addCultureItem(CultureItem item) {
-        mItemList.add(item);
-        mRowList.add(item.toFeedRow());
-        mAdapter.notifyDataSetChanged();
-    }
-
-    private class OnGetItemResponse implements Callback<CultureItem> {
-        @Override
-        public void onResponse(Call<CultureItem> call, Response<CultureItem> response) {
-            if (response.isSuccessful()) {
-                addCultureItem(response.body());
-            } else {
-                // TODO: Error checking
-            }
-        }
-
-        @Override
-        public void onFailure(Call<CultureItem> call, Throwable t) {
-            // TODO: Check network connections
-        }
     }
 }
 

--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/home/HomeActivity.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/home/HomeActivity.java
@@ -23,20 +23,19 @@ import com.bounswe2017.group10.atlas.profil.ProfileActivity;
 import com.bounswe2017.group10.atlas.util.Constants;
 import com.bounswe2017.group10.atlas.httpbody.UserResponse;
 import com.bounswe2017.group10.atlas.remote.APIUtils;
+import com.bounswe2017.group10.atlas.util.Utils;
 
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 
-import static com.bounswe2017.group10.atlas.util.Utils.tokenToAuthString;
+import static com.bounswe2017.group10.atlas.util.Utils.getSharedPref;
 
 
 public class HomeActivity extends FragmentActivity implements NavigationView.OnNavigationItemSelectedListener{
 
     private static final String TAG = "HomeActivity";
 
-
-    private String authStr;
     private TabPagerAdapter mAdapter;
     private ViewPager mPager;
     private TabLayout mTabs;
@@ -44,10 +43,10 @@ public class HomeActivity extends FragmentActivity implements NavigationView.OnN
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        authStr = getIntent().getStringExtra(Constants.AUTH_STR);
         setContentView(R.layout.navigate_bar);
 
         //add username and email to navigation bar
+        String authStr = getSharedPref(this).getString(Constants.AUTH_STR, Constants.NO_AUTH_STR);
         APIUtils.serverAPI().getMe(authStr).enqueue(new Callback<UserResponse>() {
             @Override
             public void onResponse(Call<UserResponse> call, Response<UserResponse> response) {
@@ -88,7 +87,7 @@ public class HomeActivity extends FragmentActivity implements NavigationView.OnN
 
     @Override
     public void onBackPressed() {
-        DrawerLayout drawer = (DrawerLayout) findViewById(R.id.nav_layout);
+        DrawerLayout drawer = findViewById(R.id.nav_layout);
         if (drawer.isDrawerOpen(GravityCompat.START)) {
             drawer.closeDrawer(GravityCompat.START);
         } else {
@@ -110,12 +109,15 @@ public class HomeActivity extends FragmentActivity implements NavigationView.OnN
         int id = item.getItemId();
 
         if (id == R.id.profil) {
-            Intent intent = new Intent(this, ProfileActivity.class).putExtra(Constants.AUTH_STR, authStr);
+            Intent intent = new Intent(this, ProfileActivity.class);
             this.startActivity(intent);
         } else if(id == R.id.gallery){
 
         } else if (id == R.id.logout) {
-            Intent intent = new Intent(this, AuthActivity.class).putExtra(Constants.AUTH_STR, authStr);
+            // remove token from sharedpref
+            Utils.getSharedPrefEditor(this).remove(Constants.AUTH_STR).apply();
+            // go to authentication activity
+            Intent intent = new Intent(this, AuthActivity.class);
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK|Intent.FLAG_ACTIVITY_NEW_TASK);
             this.startActivity(intent);
         }
@@ -126,13 +128,8 @@ public class HomeActivity extends FragmentActivity implements NavigationView.OnN
     }
 
     private TabPagerAdapter initAdapter() {
-        Bundle bundle = new Bundle();
-        bundle.putString(Constants.AUTH_STR, authStr);
-
         Fragment feedFragment = new FeedFragment();
-        feedFragment.setArguments(bundle);
         Fragment createItemFragment = new CreateItemFragment();
-        createItemFragment.setArguments(bundle);
 
         TabPagerAdapter adapter = new TabPagerAdapter(getSupportFragmentManager());
         adapter.addFragment(feedFragment, getResources().getString(R.string.feed));

--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/home/ViewItemFragment.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/home/ViewItemFragment.java
@@ -15,37 +15,24 @@ import com.bumptech.glide.Glide;
 
 public class ViewItemFragment extends Fragment {
 
-    TextView viewItemTitle;
-    ImageView viewItemImage;
-    TextView viewItemDesc;
-    CultureItem item;
-
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_view_item, container, false);
 
-        viewItemTitle = view.findViewById(R.id.itemTitle);
-        viewItemImage = view.findViewById(R.id.itemImage);
-        viewItemDesc = view.findViewById(R.id.itemDesc);
-        String authStr = getArguments().getString(Constants.AUTH_STR, "NO_TOKEN");
+        CultureItem item = getArguments().getParcelable(Constants.CULTURE_ITEM);
+
+        TextView viewItemTitle = view.findViewById(R.id.itemTitle);
+        ImageView viewItemImage = view.findViewById(R.id.itemImage);
+        TextView viewItemDesc = view.findViewById(R.id.itemDesc);
         viewItemTitle.setText(item.getTitle());
         viewItemDesc.setText(item.getDescription());
 
-        //if (!item.getImageList().isEmpty()) {
-        try {
-            Glide.with(this)
-                    .load(item.getImageList().get(0).getUrl())
-                    .into(viewItemImage);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        //}
+        Glide.with(getActivity())
+                .load(item.getImageList().get(0).getUrl())
+                .into(viewItemImage);
 
         return view;
     }
 
-    public void setObj (CultureItem itemC) {
-        this.item = itemC;
-    }
 }

--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/httpbody/CultureItem.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/httpbody/CultureItem.java
@@ -42,6 +42,8 @@ public class CultureItem implements Parcelable {
     @Expose
     private Boolean publicAccessibility;
 
+    public CultureItem() {}
+
     @SuppressWarnings("unchecked")
     public CultureItem(Parcel in) {
         this.country = in.readString();

--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/httpbody/CultureItem.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/httpbody/CultureItem.java
@@ -1,12 +1,16 @@
 package com.bounswe2017.group10.atlas.httpbody;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import com.bounswe2017.group10.atlas.adapter.FeedRow;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.ArrayList;
 import java.util.List;
 
-public class CultureItem {
+public class CultureItem implements Parcelable {
 
     // TODO : We need the id of the item here as a variable.
 
@@ -32,11 +36,52 @@ public class CultureItem {
 
     @SerializedName("images")
     @Expose
-    private List<Image> imageList;
+    private ArrayList<Image> imageList;
 
     @SerializedName("public_accessibility")
     @Expose
     private Boolean publicAccessibility;
+
+    @SuppressWarnings("unchecked")
+    public CultureItem(Parcel in) {
+        this.country = in.readString();
+        this.title = in.readString();
+        this.description = in.readString();
+        this.continent = in.readString();
+        this.city = in.readString();
+        this.imageList = (ArrayList<Image>)in.readSerializable();
+        this.publicAccessibility = in.readByte() != 0;
+
+    }
+
+    @Override
+    public void writeToParcel(Parcel out, int flags) {
+        out.writeString(this.country);
+        out.writeString(this.title);
+        out.writeString(this.description);
+        out.writeString(this.continent);
+        out.writeString(this.city);
+        out.writeSerializable(this.imageList);
+        out.writeByte((byte) (this.publicAccessibility ? 1 : 0));
+    }
+
+    @Override
+    public int describeContents() {
+        return this.hashCode();
+    }
+
+    public static final Parcelable.Creator<CultureItem> CREATOR =
+        new Parcelable.Creator<CultureItem>() {
+            @Override
+            public CultureItem createFromParcel(Parcel in) {
+                return new CultureItem(in);
+            }
+
+            @Override
+            public CultureItem[] newArray(int count) {
+                return new CultureItem[count];
+            }
+        };
 
     public String getCountry() {
         return country;
@@ -78,11 +123,11 @@ public class CultureItem {
         this.city = city;
     }
 
-    public List<Image> getImageList() {
+    public ArrayList<Image> getImageList() {
         return imageList;
     }
 
-    public void setImageList(List<Image> imageList) {
+    public void setImageList(ArrayList<Image> imageList) {
         this.imageList = imageList;
     }
 

--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/remote/API.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/remote/API.java
@@ -9,6 +9,8 @@ import com.bounswe2017.group10.atlas.httpbody.SignupRequest;
 import com.bounswe2017.group10.atlas.httpbody.SignupResponse;
 import com.bounswe2017.group10.atlas.httpbody.UserResponse;
 
+import java.util.List;
+
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
@@ -28,6 +30,9 @@ public interface API {
 
     @GET("/cultural_heritage_item/{id}")
     Call<CultureItem> getItem(@Header("Authorization") String authStr, @Path("id") long id);
+
+    @GET("/cultural_heritage_item")
+    Call<List<CultureItem>> getAllItems(@Header("Authorization") String authStr);
 
     @GET("/api/auth/me")
     Call<UserResponse> getMe(@Header("Authorization") String authStr);

--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/response/OnGetAllItemsResponse.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/response/OnGetAllItemsResponse.java
@@ -1,0 +1,56 @@
+package com.bounswe2017.group10.atlas.response;
+
+import android.content.Context;
+
+import com.bounswe2017.group10.atlas.R;
+import com.bounswe2017.group10.atlas.adapter.FeedListAdapter;
+import com.bounswe2017.group10.atlas.adapter.FeedRow;
+import com.bounswe2017.group10.atlas.httpbody.CultureItem;
+import com.bounswe2017.group10.atlas.util.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+
+public class OnGetAllItemsResponse implements Callback<List<CultureItem>> {
+
+    private Context context;
+    private final ArrayList<CultureItem> mItemList;
+    private final ArrayList<FeedRow> mRowList;
+    private FeedListAdapter mAdapter;
+
+    public OnGetAllItemsResponse(Context context, ArrayList<CultureItem> itemList, ArrayList<FeedRow> rowList, FeedListAdapter adapter) {
+        this.context = context;
+        this.mItemList = itemList;
+        this.mRowList = rowList;
+        this.mAdapter = adapter;
+    }
+
+    @Override
+    public void onResponse(Call<List<CultureItem>> call, Response<List<CultureItem>> response) {
+        if (response.isSuccessful()) {
+            Utils.showToast(context, context.getResources().getString(R.string.successful_create_item));
+
+            // add all items to given item lists
+            List<CultureItem> responseItemList = response.body();
+            for (CultureItem item : responseItemList) {
+                mItemList.add(item);
+                mRowList.add(item.toFeedRow());
+            }
+            mAdapter.notifyDataSetChanged();
+        } else {
+            Utils.showToast(context, "Create Item Error!");
+        }
+    }
+
+    @Override
+    public void onFailure(Call<List<CultureItem>> call, Throwable t) {
+        Utils.showToast(context, context.getResources().getString(R.string.connection_failure));
+        // TODO: do logging
+    }
+}
+

--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/response/OnLoginResponse.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/response/OnLoginResponse.java
@@ -3,6 +3,7 @@ package com.bounswe2017.group10.atlas.response;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.util.Log;
 import android.view.View;
 import android.widget.ProgressBar;
@@ -11,6 +12,7 @@ import com.bounswe2017.group10.atlas.R;
 import com.bounswe2017.group10.atlas.home.HomeActivity;
 import com.bounswe2017.group10.atlas.httpbody.LoginResponse;
 import com.bounswe2017.group10.atlas.util.Constants;
+import com.bounswe2017.group10.atlas.util.Utils;
 
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -36,8 +38,15 @@ public class OnLoginResponse implements Callback<LoginResponse> {
     public void onResponse(Call<LoginResponse> call, Response<LoginResponse> response) {
         progress.setVisibility(View.GONE);
         if (response.isSuccessful()) {
+            // store authentication string in SharedPreferences
             String token = response.body().getToken();
-            startHomeActivity(token);
+            String authStr = Utils.tokenToAuthString(token);
+            Utils.getSharedPrefEditor(context).putString(Constants.AUTH_STR, authStr).apply();
+
+            // go to home activity
+            Intent intent = new Intent(context, HomeActivity.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK|Intent.FLAG_ACTIVITY_NEW_TASK);
+            context.startActivity(intent);
         } else if (response.code() == 400) {
             showToast(context.getApplicationContext(), context.getResources().getString(R.string.wrong_credentials));
         }
@@ -50,17 +59,5 @@ public class OnLoginResponse implements Callback<LoginResponse> {
         Log.d(TAG, "LOGIN connection failure: " + t.toString());
         Log.d(TAG, "LOGIN connection failure isExecuted: " + call.isExecuted());
         Log.d(TAG, "LOGIN connection failure isCanceled: " + call.isCanceled());
-    }
-
-    /**
-     * Start home activity with the given token.
-     *
-     * @param token Access token obtained from the server.
-     */
-    private void startHomeActivity(String token) {
-        String authStr = tokenToAuthString(token);
-        Intent intent = new Intent(context, HomeActivity.class).putExtra(Constants.AUTH_STR, authStr);
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK|Intent.FLAG_ACTIVITY_NEW_TASK);
-        context.startActivity(intent);
     }
 }

--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/util/Constants.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/util/Constants.java
@@ -4,4 +4,6 @@ package com.bounswe2017.group10.atlas.util;
 public class Constants {
 
     public static final String AUTH_STR = "authStr";
+    public static final String NO_AUTH_STR = "NO_TOKEN";
+    public static final String CULTURE_ITEM = "CULTURE_ITEM";
 }

--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/util/Utils.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/util/Utils.java
@@ -1,7 +1,10 @@
 package com.bounswe2017.group10.atlas.util;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.widget.Toast;
+
+import com.bounswe2017.group10.atlas.R;
 
 /**
  * A class that contains general utility methods.
@@ -14,5 +17,16 @@ public class Utils {
 
     public static void showToast(Context context, String errorMessage) {
         Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show();
+    }
+
+    public static SharedPreferences.Editor getSharedPrefEditor(Context context) {
+        SharedPreferences preferences = context.getSharedPreferences(context.getString(R.string.shared_pref_file), Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = preferences.edit();
+        return editor;
+    }
+
+    public static SharedPreferences getSharedPref(Context context) {
+        SharedPreferences preferences = context.getSharedPreferences(context.getString(R.string.shared_pref_file), Context.MODE_PRIVATE);
+        return preferences;
     }
 }

--- a/Atlas/android/app/src/main/res/values/strings.xml
+++ b/Atlas/android/app/src/main/res/values/strings.xml
@@ -36,4 +36,5 @@
     <string name="ok">OK</string>
     <string name="cancel">Cancel</string>
     <string name="successful_create_item">You have successfully created a new topic!</string>
+    <string name="shared_pref_file">atlas_conf</string>
 </resources>


### PR DESCRIPTION
This PR implements storing token obtained from server in device local storage (```SharedPreferences```). Main points are

1. Store token upon successful login and remove it upon logout.
2. If there is a token stored in user device, automatically log user in and show the feed.
  * To make this feature work properly, we need to implement **token-refresh** ability in later stages. But for now, it should be sufficient.
3. Make code adjustments to show all the items to user in feed.