### PR TITLE
Put list of admins to django settings

### DIFF
--- a/Atlas/backend/atlas/settings.py
+++ b/Atlas/backend/atlas/settings.py
@@ -183,3 +183,8 @@ JWT_AUTH = {
 
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
 }
+
+ADMINS = [('Yiğit Özkavcı', 'yigitozkavci8@gmail.com'),
+          ('Eşref Özdemir', 'esref.ozdemir27@gmail.com'),
+          ('Talha Nişancı', 's.talhanisanci@gmail.com'),
+          ('Aykut Bozkurt', 'aykut___1995@hotmail.com')]

--- a/Atlas/backend/atlas/settings.py
+++ b/Atlas/backend/atlas/settings.py
@@ -184,7 +184,7 @@ JWT_AUTH = {
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
 }
 
-ADMINS = [('Yiğit Özkavcı', 'yigitozkavci8@gmail.com'),
-          ('Eşref Özdemir', 'esref.ozdemir27@gmail.com'),
-          ('Talha Nişancı', 's.talhanisanci@gmail.com'),
+ADMINS = [('Yigit Ozkavci', 'yigitozkavci8@gmail.com'),
+          ('Esref Ozdemir', 'esref.ozdemir27@gmail.com'),
+          ('Talha Nisanci', 's.talhanisanci@gmail.com'),
           ('Aykut Bozkurt', 'aykut___1995@hotmail.com')]


### PR DESCRIPTION
Fixes #165

Changes proposed in this pull request:
- Update `ADMINS` field in settings file. This lets us get e-mail notifications in case of an unhandled exception throw on production server.
