### PR TITLE
Fix 'unable to upload image' when only image URLs are given bug.

### DIFF
--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/response/OnUploadImagesResponse.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/response/OnUploadImagesResponse.java
@@ -41,6 +41,7 @@ public class OnUploadImagesResponse implements Callback<Void> {
         if (response.isSuccessful()) {
             Utils.showToast(context, context.getResources().getString(R.string.successful_create_item));
             createFragment.clearView();
+            createFragment.getActivity().onBackPressed();
         } else {
             Utils.showToast(context, context.getString(R.string.create_item_no_images));
         }


### PR DESCRIPTION
Fixes a bug where a user is unable to upload images when they are given only as URLs.

Changes proposed in this pull request:
- Fix bug by directly uploading URLs to server instead of going to Cloudinary upload path.
