### PR TITLE
add endpoint to find nearby items

### DIFF
--- a/Atlas/backend/atlas/tests/test_search.py
+++ b/Atlas/backend/atlas/tests/test_search.py
@@ -253,3 +253,69 @@ class cultural_heritage_item(TestCase):
         response_content = json.loads(smart_text(response.content))
         self.assertEqual(len(response_content['results']), 3);
 
+    def test_nearby_search(self):
+        item_data = {
+            "title": "Draven montage",
+            "longitude": "23.123523",
+            "latitude": "21.123523",
+        }
+        response = self.client.post(
+            self.cultural_heritage_item_url,
+            item_data,
+            format='json',
+
+        )
+        self.assertEqual(response.status_code, 201)
+
+        item_data = {
+            "title": "Elo"
+        }
+        response = self.client.post(
+            self.cultural_heritage_item_url,
+            item_data,
+            format='json',
+
+        )
+        self.assertEqual(response.status_code, 201)
+
+        item_data = {
+            "title": "thresh montage",
+            "longitude": "50.123523",
+            "latitude": "23.123523",
+        }
+        response = self.client.post(
+            self.cultural_heritage_item_url,
+            item_data,
+            format='json',
+
+        )
+        self.assertEqual(response.status_code, 201)
+        item_data = {
+            "title": "Ahri montage",
+            "longitude": "-87.123523",
+            "latitude": "-85.123523",
+        }
+        response = self.client.post(
+            self.cultural_heritage_item_url,
+            item_data,
+            format='json',
+
+        )
+        self.assertEqual(response.status_code, 201)
+        location_data = {
+            'longitude': "12.51231",
+            'latitude': "11.51231",
+
+        }
+        response = self.client.get(
+            '/nearby_items',
+            location_data,
+            format ='json'
+
+        )
+        response_content = json.loads(smart_text(response.content))
+        self.assertEqual(response_content['results'][0]['title'],'Draven montage')
+        self.assertEqual(response_content['results'][1]['title'],'thresh montage')
+        self.assertEqual(response_content['results'][2]['title'],'Ahri montage')
+
+

--- a/Atlas/backend/atlas/urls.py
+++ b/Atlas/backend/atlas/urls.py
@@ -39,6 +39,7 @@ urlpatterns = [
     url(r'^cultural_heritage_item/search_autocorrect/(?P<query>\w{1,50})/?$', views.cultural_heritage_item_search_autocorrect.as_view()),
     url(r'^user/cultural_heritage_item/(?P<heritage_id>[0-9]+)/favorite/?$', views.user_favorite_item.as_view()),
     url(r'^user/cultural_heritage_item/favorite/?$', views.get_user_favorite_items.as_view()),
+    url(r'^nearby_items/?$', views.nearby_search.as_view()),
 
 ]
 

--- a/Atlas/backend/atlas/views.py
+++ b/Atlas/backend/atlas/views.py
@@ -11,6 +11,7 @@ from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from jwt_auth.compat import json
 from django.contrib.postgres.search import SearchVector
 
+import geopy.distance
 
 
 
@@ -166,4 +167,19 @@ class cultural_heritage_item_search_autocorrect(generics.ListAPIView):
     def get_queryset(self):
         query = self.kwargs.get('query')
         return Cultural_Heritage.objects.filter(title__icontains=query)
+
+
+class nearby_search(generics.ListAPIView):
+    serializer_class =  cultural_heritage_serializer
+    def get_queryset(self):
+        longitude = float(self.request.GET['longitude'])
+        latitude = float(self.request.GET['latitude'])
+        self.baseCoor = (longitude,latitude)
+        objects = Cultural_Heritage.objects.all().exclude(longitude=None).exclude(latitude=None)
+        return sorted(objects,key= self.dist)
+
+
+    def dist(self,item):
+        coord = (item.longitude,item.latitude )
+        return geopy.distance.vincenty(self.baseCoor,coord).km
 

--- a/Atlas/backend/requirements.txt
+++ b/Atlas/backend/requirements.txt
@@ -26,3 +26,4 @@ six==1.10.0
 urllib3==1.13.1
 virtualenv==15.1.0
 django-rest-swagger==2.1.2
+geopy==1.11.0


### PR DESCRIPTION
By sending a **HTTP GET** request to `/nearby_items` with **longitude** and **latitude** informations as string, you can get the nearby items of that location. In the returned list there wont be any items with missing location information.