### PR TITLE
Listadapter bugfix

### DIFF
--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/adapter/ListItemsAdapter.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/adapter/ListItemsAdapter.java
@@ -87,7 +87,9 @@ public class ListItemsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             }
             etTitle.setText(row.getTitle());
             etDescr.setText(row.getDescription());
-            etLocation.setText(row.getLocation());
+            if (row.getLocation() != null) {
+                etLocation.setText(row.getLocation());
+            }
             etFavorite.setText(row.getFavoriteCount());
             etCreator.setText(context.getString(R.string.created_by, row.getCreatorUsername()));
 
@@ -99,14 +101,8 @@ public class ListItemsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
             if (row.getYear() != null) {
                 int[] yearPair = FeedRow.fromYearFormat(row.getYear());
-                String start = Integer.toString(yearPair[0]);
-                if (yearPair[0] < 0) {
-                    start = start.substring(1) + "BC";
-                }
-                String end = Integer.toString(yearPair[1]);
-                if (yearPair[1] < 0) {
-                    end = end.substring(1) + "BC";
-                }
+                String start = Utils.yearString(yearPair[0]);
+                String end = Utils.yearString(yearPair[1]);
                 etYear.setText(context.getString(R.string.year_string, start, end));
             }
 

--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/adapter/ListItemsAdapter.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/adapter/ListItemsAdapter.java
@@ -89,6 +89,8 @@ public class ListItemsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             etDescr.setText(row.getDescription());
             if (row.getLocation() != null) {
                 etLocation.setText(row.getLocation());
+            } else {
+                etLocation.setText(context.getString(R.string.no_location));
             }
             etFavorite.setText(row.getFavoriteCount());
             etCreator.setText(context.getString(R.string.created_by, row.getCreatorUsername()));
@@ -104,6 +106,8 @@ public class ListItemsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                 String start = Utils.yearString(yearPair[0]);
                 String end = Utils.yearString(yearPair[1]);
                 etYear.setText(context.getString(R.string.year_string, start, end));
+            } else {
+                etYear.setText(context.getString(R.string.no_date));
             }
 
             Glide.with(context)

--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/home/ViewItemFragment.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/home/ViewItemFragment.java
@@ -316,19 +316,17 @@ public class ViewItemFragment extends Fragment {
      * @param twTitle TextView responsible for showing the title of the CultureItem.
      * @param twDescription TextView responsible for showing the description of the CultureItem.
      * @param item CultureItem object.
-     *
-     * TODO: Show other text information of a CultureItem.
      */
     private void setText(TextView twTitle, TextView twDescription, TextView twLocation,
                          TextView twDate, TextView twOwner, TextView twFavCount, CultureItem item) {
         twTitle.setText(item.getTitle());
         twDescription.setText(item.getDescription());
         twLocation.setText(item.getPlaceName());
-        if(item.getStartYear() != null && item.getEndYear() != null)
-            twDate.setText(getActivity().getString(R.string.year_string, Integer.toString(item.getStartYear()),
-                    Integer.toString(item.getEndYear())));
-        else if (item.getStartYear() != null)
-            twDate.setText(item.getStartYear());
+        if(item.getStartYear() != null && item.getEndYear() != null) {
+            String startYearStr = Utils.yearString(item.getStartYear());
+            String endYearStr = Utils.yearString(item.getEndYear());
+            twDate.setText(getString(R.string.year_string, startYearStr, endYearStr));
+        }
         twOwner.setText(item.getUserInfo().getUsername());
         twFavCount.setText(item.getFavoriteCount());
 

--- a/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/util/Utils.java
+++ b/Atlas/android/app/src/main/java/com/bounswe2017/group10/atlas/util/Utils.java
@@ -197,4 +197,19 @@ public class Utils {
         }
         return year >= Constants.MIN_YEAR && year <= Constants.MAX_YEAR;
     }
+
+    /**
+     * Given a negative or positive year, this function converts the year to
+     * the format <abs(year)>BC if year is negative, and <year> if not.
+     *
+     * @param year An integer representing a year.
+     * @return A string representation of the year with BC suffix if needed.
+     */
+    public static String yearString(int year) {
+        String yearStr = Integer.toString(year);
+        if (year < 0) {
+            yearStr = yearStr.substring(1) + "BC";
+        }
+        return yearStr;
+    }
 }

--- a/Atlas/android/app/src/main/res/layout/fragment_view_item.xml
+++ b/Atlas/android/app/src/main/res/layout/fragment_view_item.xml
@@ -48,6 +48,7 @@
                 android:id="@+id/location_textview_detail"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:text="@string/no_location"
                 android:layout_weight="1"
                 android:layout_marginTop="2dp"
                 android:drawableStart="@drawable/ic_place_black_24dp"
@@ -83,6 +84,7 @@
             <TextView
                 android:id="@+id/year_textview_detail"
                 android:layout_width="0dp"
+                android:text="@string/no_date"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="2dp"
                 android:layout_weight="1"

--- a/Atlas/android/app/src/main/res/layout/list_item_layout.xml
+++ b/Atlas/android/app/src/main/res/layout/list_item_layout.xml
@@ -134,6 +134,7 @@
                 android:id="@+id/location_textview"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:text="@string/no_location"
                 android:layout_weight="1.25"
                 android:layout_marginTop="2dp"
                 android:drawableStart="@drawable/ic_place_black_24dp"
@@ -153,6 +154,7 @@
                 android:layout_height="wrap_content"
                 android:maxLines="1"
                 android:ellipsize="end"
+                android:text="@string/no_date"
                 android:layout_marginTop="2dp"
                 android:drawableStart="@drawable/ic_date_range_black_24dp"
                 android:gravity="center" />

--- a/Atlas/android/app/src/main/res/values/strings.xml
+++ b/Atlas/android/app/src/main/res/values/strings.xml
@@ -109,4 +109,6 @@
     <string name="my_heritages">My Heritages</string>
     <string name="my_favourites">My Favourites</string>
     <string name="featured">Featured</string>
+    <string name="no_date">No date</string>
+    <string name="no_location">No location</string>
 </resources>


### PR DESCRIPTION
Fixes #394 .

Changes proposed in this pull request:
- Show "No Location" and "No Date" strings when there is no location or date on the item, respectively.
  * We show these strings both in ListItemsFragment, and in ViewItemsFragment
- Show years before 0 with BC instead of minus sign on ViewItemsFragment
- Fix showing incorrect date and location information in ListItemsFragment.
  * We used to show location or date information only when they were present. Although this is correct, what we haven't done is deciding on what to show if they were not present. With this PR, we show "No location" and "no date" in this case, and avoid caching issues due to ViewHolder pattern on RecyclerView objects.