### PR TITLE
add account update end point and tests

### DIFF
--- a/Atlas/backend/authentication/permissions.py
+++ b/Atlas/backend/authentication/permissions.py
@@ -1,0 +1,9 @@
+from rest_framework.permissions import BasePermission
+
+class KWArgCheck(BasePermission):
+
+    """
+        Check if username given in url arguments matches authenticated user's username
+    """
+    def has_permission(self, request, view):
+        return request.user.get_username() == view.kwargs['username']

--- a/Atlas/backend/authentication/urls.py
+++ b/Atlas/backend/authentication/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 from rest_framework_jwt.views import refresh_jwt_token, verify_jwt_token, ObtainJSONWebToken
 from .serializers import CustomJWTSerializer
-from .views import AuthRegister, user
+from .views import AuthRegister, user, AccountUpdate
 
 urlpatterns = [
     url(r'^login/?$', ObtainJSONWebToken.as_view(serializer_class=CustomJWTSerializer)),
@@ -9,4 +9,5 @@ urlpatterns = [
     url(r'^token-verify/', verify_jwt_token),
     url(r'^signup/?$', AuthRegister.as_view()),
     url(r'^me/?$', user),
+    url(r'^me/(?P<username>\w+)/?$', AccountUpdate.as_view()),
 ]


### PR DESCRIPTION
Fixes #350  .

Changes proposed in this pull request:
- update multiple fields of user account.

Notes:

- You can update  `email`, `profile_picture`, `firstname`, `lastname` and `password` fields by sending a **PATCH** request to `/api/auth/me/<username>/` address. `username` being the username of logged in user.
- `old_password`, `password` and `confirm_password` fields are required to change the password. 
- One or more fields can be sent at once.

@SaitTalhaNisanci 
